### PR TITLE
[feat/purchase] 제품 구매 controller 추가 및 기본 api 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,7 @@ repositories {
 }
 
 dependencies {
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 	implementation 'org.springframework.kafka:spring-kafka'
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/main/java/com/example/hot_deal/common/config/ApiV1.java
+++ b/src/main/java/com/example/hot_deal/common/config/ApiV1.java
@@ -1,0 +1,14 @@
+package com.example.hot_deal.common.config;
+
+import org.springframework.stereotype.Component;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(value = RetentionPolicy.RUNTIME)
+@Component
+public @interface ApiV1 {
+}

--- a/src/main/java/com/example/hot_deal/common/config/CustomPageSerializer.java
+++ b/src/main/java/com/example/hot_deal/common/config/CustomPageSerializer.java
@@ -1,0 +1,20 @@
+package com.example.hot_deal.common.config;
+
+import com.example.hot_deal.common.domain.PageResponse;
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+import org.springframework.boot.jackson.JsonComponent;
+import org.springframework.data.domain.Page;
+
+import java.io.IOException;
+
+@JsonComponent
+public class CustomPageSerializer <T> extends JsonSerializer<Page<T>> {
+
+    @Override
+    public void serialize(Page<T> page, JsonGenerator gen, SerializerProvider serializers) throws IOException {
+        PageResponse<T> response = PageResponse.from(page);
+        gen.writeObject(response);
+    }
+}

--- a/src/main/java/com/example/hot_deal/common/config/SwaggerConfig.java
+++ b/src/main/java/com/example/hot_deal/common/config/SwaggerConfig.java
@@ -1,0 +1,19 @@
+package com.example.hot_deal.common.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.OpenAPI;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@OpenAPIDefinition(
+        info = @io.swagger.v3.oas.annotations.info.Info(title = "Hot Deal API 명세서",
+                description = "정시에 오픈하는 제품 판매 서비스입니다.",
+                version = "v1"))
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI();
+    }
+}

--- a/src/main/java/com/example/hot_deal/common/config/WebConfig.java
+++ b/src/main/java/com/example/hot_deal/common/config/WebConfig.java
@@ -1,0 +1,24 @@
+package com.example.hot_deal.common.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.method.HandlerTypePredicate;
+import org.springframework.web.servlet.config.annotation.PathMatchConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.util.UrlPathHelper;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    public static final String API_V1 = "/api/v1";
+
+    @Override
+    public void configurePathMatch(PathMatchConfigurer configurer) {
+        configurer
+                .addPathPrefix(API_V1, HandlerTypePredicate.forAnnotation(ApiV1.class))
+                .setPathMatcher(new AntPathMatcher())
+                .setUrlPathHelper(new UrlPathHelper());
+    }
+}

--- a/src/main/java/com/example/hot_deal/common/domain/PageResponse.java
+++ b/src/main/java/com/example/hot_deal/common/domain/PageResponse.java
@@ -1,0 +1,29 @@
+package com.example.hot_deal.common.domain;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Schema(description = "커스텀된 페이지 응답 DTO")
+public record PageResponse<E>(
+        boolean hasNext,
+        List<E> items,
+        int pageNumber,
+        int pageSize,
+        int totalPages,
+        long totalElements,
+        boolean isLast
+) {
+    public static <E> PageResponse<E> from(final Page<E> page) {
+        return new PageResponse<>(
+                page.hasNext(),
+                page.getContent(),
+                page.getNumber(),
+                page.getSize(),
+                page.getTotalPages(),
+                page.getTotalElements(),
+                page.isLast()
+        );
+    }
+}

--- a/src/main/java/com/example/hot_deal/product/controller/ProductController.java
+++ b/src/main/java/com/example/hot_deal/product/controller/ProductController.java
@@ -2,7 +2,10 @@ package com.example.hot_deal.product.controller;
 
 import com.example.hot_deal.product.dto.ProductDTO;
 import com.example.hot_deal.product.service.ProductService;
+import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -18,7 +21,11 @@ public class ProductController {
     private final ProductService productService;
 
     @GetMapping
-    public ResponseEntity<List<ProductDTO>> getProducts() {
-        return ResponseEntity.ok(productService.getProducts());
+    public ResponseEntity<Page<ProductDTO>> getProducts(
+            @Parameter(hidden = true) Pageable pageable
+    ) {
+        return ResponseEntity.ok(
+                productService.getProducts(pageable)
+        );
     }
 }

--- a/src/main/java/com/example/hot_deal/product/controller/ProductController.java
+++ b/src/main/java/com/example/hot_deal/product/controller/ProductController.java
@@ -1,0 +1,24 @@
+package com.example.hot_deal.product.controller;
+
+import com.example.hot_deal.product.dto.ProductDTO;
+import com.example.hot_deal.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/product")
+@RequiredArgsConstructor
+public class ProductController {
+
+    private final ProductService productService;
+
+    @GetMapping
+    public ResponseEntity<List<ProductDTO>> getProducts() {
+        return ResponseEntity.ok(productService.getProducts());
+    }
+}

--- a/src/main/java/com/example/hot_deal/product/controller/ProductController.java
+++ b/src/main/java/com/example/hot_deal/product/controller/ProductController.java
@@ -1,8 +1,14 @@
 package com.example.hot_deal.product.controller;
 
+import com.example.hot_deal.common.config.ApiV1;
+import com.example.hot_deal.common.domain.PageResponse;
 import com.example.hot_deal.product.dto.ProductDTO;
 import com.example.hot_deal.product.service.ProductService;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,8 +17,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
-
+@ApiV1
 @RestController
 @RequestMapping("/product")
 @RequiredArgsConstructor
@@ -20,7 +25,20 @@ public class ProductController {
 
     private final ProductService productService;
 
+    /**
+     * 판매 제품 목록 조회
+     * 현재는 sorting 설정을 따로 해주지는 않았지만, 필요하다면 할 수 있습니다.
+     */
     @GetMapping
+    @Operation(summary = "제품 목록 조회", description = "사용자는 제품 목록을 조회할 수 있다. 기본은 10개씩이며 URL?page=0&size=2와 같이 쿼리로 사용할 수 있다.")
+    @ApiResponse(
+            responseCode = "200",
+            description = "성공적으로 제품 목록을 조회했습니다.",
+            content = @Content(
+                    mediaType = "application/json",
+                    schema = @Schema(implementation = PageResponse.class)
+            )
+    )
     public ResponseEntity<Page<ProductDTO>> getProducts(
             @Parameter(hidden = true) Pageable pageable
     ) {

--- a/src/main/java/com/example/hot_deal/product/domain/entity/Product.java
+++ b/src/main/java/com/example/hot_deal/product/domain/entity/Product.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -29,6 +30,9 @@ public class Product extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Long stockQuantity;
+
+    @Column(nullable = false)
+    private LocalDateTime openTime;
 
     public boolean decreaseQuantity() {
         if (this.stockQuantity <= 0) {

--- a/src/main/java/com/example/hot_deal/product/dto/ProductDTO.java
+++ b/src/main/java/com/example/hot_deal/product/dto/ProductDTO.java
@@ -1,0 +1,27 @@
+package com.example.hot_deal.product.dto;
+
+import lombok.AllArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import com.example.hot_deal.product.domain.entity.Product;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductDTO {
+    private Long id;
+    private String name;
+    private BigDecimal price;
+    private Long quantity;
+    private LocalDateTime openTime;
+
+    public ProductDTO(Product product) {
+        this.id = product.getId();
+        this.name = product.getName();
+        this.price = product.getPrice();
+        this.quantity = product.getStockQuantity();
+        this.openTime = product.getOpenTime();
+    }
+}

--- a/src/main/java/com/example/hot_deal/product/service/ProductService.java
+++ b/src/main/java/com/example/hot_deal/product/service/ProductService.java
@@ -1,9 +1,12 @@
 package com.example.hot_deal.product.service;
 
 import com.example.hot_deal.product.domain.repository.ProductRepository;
+import com.example.hot_deal.product.dto.ProductDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Slf4j
 @Service
@@ -12,4 +15,9 @@ public class ProductService {
 
     private final ProductRepository productRepository;
 
+
+    public List<ProductDTO> getProducts() {
+        return productRepository.findAll().stream()
+                .map(ProductDTO::new).toList();
+    }
 }

--- a/src/main/java/com/example/hot_deal/product/service/ProductService.java
+++ b/src/main/java/com/example/hot_deal/product/service/ProductService.java
@@ -4,9 +4,9 @@ import com.example.hot_deal.product.domain.repository.ProductRepository;
 import com.example.hot_deal.product.dto.ProductDTO;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
 
 @Slf4j
 @Service
@@ -15,9 +15,8 @@ public class ProductService {
 
     private final ProductRepository productRepository;
 
-
-    public List<ProductDTO> getProducts() {
-        return productRepository.findAll().stream()
-                .map(ProductDTO::new).toList();
+    public Page<ProductDTO> getProducts(Pageable pageable) {
+        return productRepository.findAll(pageable)
+                .map(ProductDTO::new);
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,9 +3,13 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: true
+    defer-datasource-initialization: true
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
     url: jdbc:mysql://127.0.0.1:3333/hot_deal
     hikari:
       username: root
       password: 1234
+  sql:
+    init:
+      mode: always

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,6 @@
+INSERT INTO products (name, price, stock_quantity, open_time)
+VALUES
+    ('Product1', 1000, 50, '2024-10-16 09:00:00'),
+    ('Product2', 5500, 100, '2024-10-16 09:00:00'),
+    ('Product3', 1500, 200, '2024-10-16 09:00:00'),
+    ('Product4', 7450, 100, '2024-10-16 09:00:00');


### PR DESCRIPTION
- 더미 데이터를 위한 sql 문 추가
- 갖고 있는 모든 product 리스트 볼 수 있는 api 추가
- CustomPageSerializer 클래스 추가
- 커스텀 애노테이션 추가
   - `@ApiV1`: `/api/v1`이 자동 설정 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- OpenAPI 문서화를 위한 SpringDoc OpenAPI 스타터 의존성 추가.
	- 제품 관련 작업을 관리하는 REST 컨트롤러 추가 및 페이지네이션 기능 구현.
	- 제품 DTO 및 서비스 클래스 수정으로 제품 목록을 페이지 단위로 검색 가능.

- **버그 수정**
	- 데이터 소스 초기화 관련 설정 수정.

- **문서화**
	- OpenAPI 문서화를 위한 새로운 구성 클래스 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->