### PR TITLE
[refactor/test] 주문 테스트 리팩토링 및 제품 목록 테스트 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,8 +51,9 @@ dependencies {
 	 */
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testImplementation 'org.awaitility:awaitility:4.2.2'
 
 	// Fixture Monkey
 	testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.27")

--- a/build.gradle
+++ b/build.gradle
@@ -24,28 +24,38 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
-	implementation 'org.springframework.kafka:spring-kafka'
+	// Spring
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
-	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
+	implementation 'org.springframework.kafka:spring-kafka'
+
+	// Doc
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.6.0'
 
 	// JWT
 	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
 
+	// Etc
+	implementation 'me.paulschwarz:spring-dotenv:4.0.0'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
+	/**
+	 * Test
+	 */
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.27")
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// Fixture Monkey
+	testImplementation("com.navercorp.fixturemonkey:fixture-monkey-starter:1.0.27")
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/hot_deal/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/example/hot_deal/order/domain/repository/OrderRepository.java
@@ -5,4 +5,6 @@ import com.example.hot_deal.order.domain.entity.Order;
 public interface OrderRepository {
 
     Order save(Order order);
+
+    void deleteAll();
 }

--- a/src/main/java/com/example/hot_deal/product/domain/entity/Product.java
+++ b/src/main/java/com/example/hot_deal/product/domain/entity/Product.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.DecimalMin;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -19,7 +20,6 @@ import java.time.LocalDateTime;
 
 @Entity
 @Getter
-@Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Table(name = "products")
@@ -40,6 +40,10 @@ public class Product extends BaseTimeEntity {
 
     @Column(nullable = false)
     private LocalDateTime openTime;
+
+    public Product(String name, BigDecimal price, Long stockQuantity, LocalDateTime openTime) {
+        this(null, name, price, stockQuantity, openTime);
+    }
 
     public boolean decreaseQuantity() {
         if (this.stockQuantity <= 0) {

--- a/src/main/java/com/example/hot_deal/product/domain/repository/ProductJpaRepository.java
+++ b/src/main/java/com/example/hot_deal/product/domain/repository/ProductJpaRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 import static com.example.hot_deal.product.constants.error.ProductErrorCode.PRODUCT_NOT_FOUND;
 
 public interface ProductJpaRepository extends ProductRepository, JpaRepository<Product, Long> {
@@ -21,4 +23,8 @@ public interface ProductJpaRepository extends ProductRepository, JpaRepository<P
     }
 
     Page<Product> findAll(Pageable pageable);
+
+    default List<Product> saveAllProducts(List<Product> products) {
+        return saveAll(products);
+    }
 }

--- a/src/main/java/com/example/hot_deal/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/example/hot_deal/product/domain/repository/ProductRepository.java
@@ -13,4 +13,6 @@ public interface ProductRepository {
     Page<Product> findAll(Pageable pageable);
 
     Product save(Product product);
+
+    void deleteAll();
 }

--- a/src/main/java/com/example/hot_deal/product/domain/repository/ProductRepository.java
+++ b/src/main/java/com/example/hot_deal/product/domain/repository/ProductRepository.java
@@ -4,6 +4,8 @@ import com.example.hot_deal.product.domain.entity.Product;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface ProductRepository {
 
     Product getProductById(Long id);
@@ -15,4 +17,6 @@ public interface ProductRepository {
     Product save(Product product);
 
     void deleteAll();
+
+    List<Product> saveAllProducts(List<Product> products);
 }

--- a/src/test/java/com/example/hot_deal/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/hot_deal/auth/service/AuthServiceTest.java
@@ -6,7 +6,7 @@ import com.example.hot_deal.auth.provider.AuthProvider;
 import com.example.hot_deal.common.exception.HotDealException;
 import com.example.hot_deal.member.domain.entity.Member;
 import com.example.hot_deal.member.domain.repository.MemberRepository;
-import com.example.hot_deal.member.fixture.MemberFixture;
+import com.example.hot_deal.fixture.MemberFixture;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;

--- a/src/test/java/com/example/hot_deal/fixture/MemberFixture.java
+++ b/src/test/java/com/example/hot_deal/fixture/MemberFixture.java
@@ -1,4 +1,4 @@
-package com.example.hot_deal.member.fixture;
+package com.example.hot_deal.fixture;
 
 import com.example.hot_deal.member.domain.entity.Member;
 import com.navercorp.fixturemonkey.FixtureMonkey;

--- a/src/test/java/com/example/hot_deal/fixture/ProductFixture.java
+++ b/src/test/java/com/example/hot_deal/fixture/ProductFixture.java
@@ -1,4 +1,4 @@
-package com.example.hot_deal.product.fixture;
+package com.example.hot_deal.fixture;
 
 import com.example.hot_deal.product.domain.entity.Product;
 import com.navercorp.fixturemonkey.FixtureMonkey;

--- a/src/test/java/com/example/hot_deal/member/service/MemberServiceTest.java
+++ b/src/test/java/com/example/hot_deal/member/service/MemberServiceTest.java
@@ -5,7 +5,7 @@ import com.example.hot_deal.member.domain.entity.Member;
 import com.example.hot_deal.member.domain.repository.MemberRepository;
 import com.example.hot_deal.member.dto.RegisterRequest;
 import com.example.hot_deal.member.dto.RegisterResponse;
-import com.example.hot_deal.member.fixture.MemberFixture;
+import com.example.hot_deal.fixture.MemberFixture;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/example/hot_deal/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/hot_deal/order/service/OrderServiceTest.java
@@ -1,26 +1,20 @@
 package com.example.hot_deal.order.service;
 
-import com.example.hot_deal.order.domain.entity.Order;
+import com.example.hot_deal.member.domain.repository.MemberRepository;
+import com.example.hot_deal.member.fixture.MemberFixture;
 import com.example.hot_deal.order.domain.repository.OrderRepository;
 import com.example.hot_deal.product.domain.entity.Product;
-import com.example.hot_deal.product.domain.repository.ProductRepository;
 import com.example.hot_deal.member.domain.entity.Member;
-import com.example.hot_deal.member.domain.repository.MemberJpaRepository;
+import com.example.hot_deal.product.domain.repository.ProductRepository;
+import com.example.hot_deal.product.fixture.ProductFixture;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.redis.core.RedisTemplate;
-
-import java.math.BigDecimal;
-import java.util.List;
-import java.util.Objects;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -28,19 +22,13 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 class OrderServiceTest {
 
-    private static final String TEST_USER_NAME = "Hong";
-    private static final String TEST_USER_EMAIL = "hong@gmail.com";
-    private static final String TEST_USER_PASSWORD = "test123";
-    private static final String TEST_PRODUCT_NAME = "PRODUCT";
-    private static final BigDecimal TEST_PRODUCT_PRICE = BigDecimal.TEN;
-    private static final Long TEST_PRODUCT_STOCK = 100L;
     private static final String KEY_PREFIX = "product:count:";
 
     @Autowired
     private OrderService orderService;
 
     @Autowired
-    private MemberJpaRepository userJpaRepository;
+    private MemberRepository memberRepository;
 
     @Autowired
     private ProductRepository productRepository;
@@ -51,129 +39,83 @@ class OrderServiceTest {
     @Autowired
     private RedisTemplate<String, String> redisTemplate;
 
-    private Long userId;
-    private Long productId;
-
-    @BeforeEach
-    void setUp() {
-        Member member = createTestUser();
-        userJpaRepository.save(member);
-        userId = member.getId();
-    
-        Product product = createTestProduct();
-        productRepository.save(product);
-        productId = product.getId();
-    
-        redisTemplate.opsForValue().set(KEY_PREFIX + productId.toString(), TEST_PRODUCT_STOCK.toString());
-    }
-
-    private Member createTestUser() {
-        return Member.builder()
-                .name(TEST_USER_NAME)
-                .email(TEST_USER_EMAIL)
-                .passwordHash(TEST_USER_PASSWORD)
-                .build();
-    }
-
-    private Product createTestProduct() {
-        return Product.builder()
-                .name(TEST_PRODUCT_NAME)
-                .price(TEST_PRODUCT_PRICE)
-                .stockQuantity(TEST_PRODUCT_STOCK)
-                .build();
-    }
-
     @AfterEach
     void tearDown() {
         orderRepository.deleteAll();
         productRepository.deleteAll();
-        userJpaRepository.deleteAll();
-        redisTemplate.delete(productId.toString());
+        memberRepository.deleteAll();
     }
 
-    @Test
-    public void 동시에_100개의_구매_요청() throws InterruptedException {
-        int threadCount = 100;
-        ExecutorService executorService = Executors.newFixedThreadPool(32);
-        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+    @Nested
+    @DisplayName("구매 요청 테스트")
+    class OrderTest {
 
-        for (int i = 0; i < threadCount; i++) {
-            executorService.submit(() -> {
-                try {
-                    orderService.orderProduct(userId, productId);
-                } catch (Exception e) {
-                    log.error("주문 처리 중 오류 발생: {}", e.getMessage());
-                } finally {
-                    countDownLatch.countDown();
-                }
-            });
+        @Test
+        @DisplayName("구매 요청 성공: 1번의 구매")
+        void order() throws InterruptedException {
+            Member member = memberRepository.save(MemberFixture.memberFixture());
+            Product product = productRepository.save(ProductFixture.productFixture());
+
+            redisTemplate.opsForValue().set(KEY_PREFIX + product.getId(), product.getStockQuantity().toString());
+
+            orderService.orderProduct(member.getId(), product.getId());
+
+            // Then
+            redisTemplate.opsForValue().get(KEY_PREFIX + product.getId());
+
+            Thread.sleep(3000);
+
+            Product updatedProduct = productRepository.getProductById(product.getId());
+            assertEquals(product.getStockQuantity()- 1L, updatedProduct.getStockQuantity());
+            redisTemplate.delete(product.getId().toString());
         }
-
-        countDownLatch.await();
-
-        Thread.sleep(5000);
-
-        executorService.shutdown();
-        if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
-            log.error("ExecutorService가 제한 시간 내에 종료되지 않았습니다.");
-        }
-
-        // Redis 재고 확인
-        String stockStr = redisTemplate.opsForValue().get(KEY_PREFIX + productId.toString());
-        assertNotNull(stockStr, "Redis의 재고가 null입니다.");
-        long redisStock = Long.parseLong(stockStr);
-        
-        // DB 재고 확인
-        Product updatedProduct = productRepository.findById(productId).orElseThrow();
-        long dbStock = updatedProduct.getStockQuantity();
-        
-        // 주문 수 확인
-        long orderCount = orderRepository.count();
-
-        log.info("Redis 재고: {}", redisStock);
-        log.info("DB 재고: {}", dbStock);
-        log.info("주문 수: {}", orderCount);
-
-        assertEquals(0L, redisStock, "Redis 재고가 0이 아닙니다.");
-        assertEquals(0L, dbStock, "DB 재고가 0이 아닙니다.");
-        assertEquals(100L, orderCount, "주문 수가 100개가 아닙니다.");
     }
 
-    @Test
-    public void 한번_구매() throws InterruptedException {
-        orderService.orderProduct(userId, productId);
-
-        // Then
-        String stockStr = redisTemplate.opsForValue().get(KEY_PREFIX + productId.toString());
-
-        Thread.sleep(3000);
-
-        assertNotNull(stockStr, "재고가 null입니다.");
-        assertEquals(99L, Long.parseLong(stockStr));
-        assertEquals(1, orderRepository.count());
-
-        Product updatedProduct = productRepository.findById(productId).orElseThrow();
-        assertEquals(99L, updatedProduct.getStockQuantity());
-    }
-
-    @Test
-    public void 상품_주문시_재고가_감소하고_주문이_생성된다() throws InterruptedException {
-        // Given
-        Member member = userJpaRepository.findAll().get(0);
-        Product product = productRepository.findAll().get(0);
-        Long initialStock = product.getStockQuantity();
-
-        // When
-        orderService.orderProduct(member.getId(), product.getId());
-        Thread.sleep(3000);
-
-        // Then
-        assertEquals(initialStock - 1, Long.parseLong(Objects.requireNonNull(redisTemplate.opsForValue().get(KEY_PREFIX + product.getId().toString()))));
-
-        List<Order> orders = orderRepository.findAll();
-        assertEquals(1, orders.size());
-        Order createdOrder = orders.get(0);
-        assertEquals(member.getId(), createdOrder.getMember().getId());
-        assertEquals(product.getId(), createdOrder.getProduct().getId());
-    }
+//    @Test
+//    public void 동시에_100개의_구매_요청() throws InterruptedException {
+//        int threadCount = 100;
+//        ExecutorService executorService = Executors.newFixedThreadPool(32);
+//        CountDownLatch countDownLatch = new CountDownLatch(threadCount);
+//
+//        for (int i = 0; i < threadCount; i++) {
+//            executorService.submit(() -> {
+//                try {
+//                    orderService.orderProduct(userId, productId);
+//                } catch (Exception e) {
+//                    log.error("주문 처리 중 오류 발생: {}", e.getMessage());
+//                } finally {
+//                    countDownLatch.countDown();
+//                }
+//            });
+//        }
+//
+//        countDownLatch.await();
+//
+//        Thread.sleep(5000);
+//
+//        executorService.shutdown();
+//        if (!executorService.awaitTermination(10, TimeUnit.SECONDS)) {
+//            log.error("ExecutorService가 제한 시간 내에 종료되지 않았습니다.");
+//        }
+//
+//        // Redis 재고 확인
+//        String stockStr = redisTemplate.opsForValue().get(KEY_PREFIX + productId.toString());
+//        assertNotNull(stockStr, "Redis의 재고가 null입니다.");
+//        long redisStock = Long.parseLong(stockStr);
+//
+//        // DB 재고 확인
+//        Product updatedProduct = productRepository.findById(productId).orElseThrow();
+//        long dbStock = updatedProduct.getStockQuantity();
+//
+//        // 주문 수 확인
+//        long orderCount = orderRepository.count();
+//
+//        log.info("Redis 재고: {}", redisStock);
+//        log.info("DB 재고: {}", dbStock);
+//        log.info("주문 수: {}", orderCount);
+//
+//        assertEquals(0L, redisStock, "Redis 재고가 0이 아닙니다.");
+//        assertEquals(0L, dbStock, "DB 재고가 0이 아닙니다.");
+//        assertEquals(100L, orderCount, "주문 수가 100개가 아닙니다.");
+//    }
 }

--- a/src/test/java/com/example/hot_deal/order/service/OrderServiceTest.java
+++ b/src/test/java/com/example/hot_deal/order/service/OrderServiceTest.java
@@ -1,12 +1,12 @@
 package com.example.hot_deal.order.service;
 
 import com.example.hot_deal.member.domain.repository.MemberRepository;
-import com.example.hot_deal.member.fixture.MemberFixture;
+import com.example.hot_deal.fixture.MemberFixture;
 import com.example.hot_deal.order.domain.repository.OrderRepository;
 import com.example.hot_deal.product.domain.entity.Product;
 import com.example.hot_deal.member.domain.entity.Member;
 import com.example.hot_deal.product.domain.repository.ProductRepository;
-import com.example.hot_deal.product.fixture.ProductFixture;
+import com.example.hot_deal.fixture.ProductFixture;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/example/hot_deal/product/fixture/ProductFixture.java
+++ b/src/test/java/com/example/hot_deal/product/fixture/ProductFixture.java
@@ -1,0 +1,35 @@
+package com.example.hot_deal.product.fixture;
+
+import com.example.hot_deal.product.domain.entity.Product;
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.api.introspector.BuilderArbitraryIntrospector;
+import com.navercorp.fixturemonkey.customizer.InnerSpec;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public class ProductFixture {
+
+    static InnerSpec innerSpec = new InnerSpec()
+            .property("id", id -> id.postCondition(Long.class, it -> it > 0))
+            .property("stockQuantity", stock -> stock.postCondition(Long.class, it -> it > 10));
+
+    private static final FixtureMonkey fixtureMonkey = FixtureMonkey.builder()
+            .objectIntrospector(BuilderArbitraryIntrospector.INSTANCE)
+            .build();
+
+    public static Product createProduct() {
+        return fixtureMonkey.giveMeBuilder(Product.class)
+                .setInner(innerSpec)
+                .sample();
+    }
+
+    public static Product productFixture() {
+        return new Product(
+                "제품",
+                new BigDecimal("10000"),
+                100L,
+                LocalDateTime.now()
+        );
+    }
+}

--- a/src/test/java/com/example/hot_deal/product/service/ProductServiceTest.java
+++ b/src/test/java/com/example/hot_deal/product/service/ProductServiceTest.java
@@ -1,0 +1,59 @@
+package com.example.hot_deal.product.service;
+
+import com.example.hot_deal.fixture.ProductFixture;
+import com.example.hot_deal.product.domain.entity.Product;
+import com.example.hot_deal.product.domain.repository.ProductRepository;
+import com.example.hot_deal.product.dto.ProductDTO;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+import java.util.stream.IntStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@SpringBootTest
+class ProductServiceTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @BeforeEach
+    void cleanup() {
+        productRepository.deleteAll();
+    }
+
+    @AfterEach
+    void afterEach() {
+        productRepository.deleteAll();
+    }
+
+    @Test
+    @DisplayName("제품 목록 조회 테스트")
+    void getProducts() {
+        // Given
+        Pageable pageable = PageRequest.of(0, 10);
+        List<Product> products = IntStream.range(0, 10)
+                .mapToObj(i -> ProductFixture.productFixture())
+                .toList();
+        productRepository.saveAllProducts(products);
+
+        // When
+        Page<ProductDTO> result = productService.getProducts(pageable);
+
+        // Then
+        assertEquals(products.size(), result.getContent().size());
+    }
+}


### PR DESCRIPTION
- 주문 테스트: Fixture 클래스 사용하도록 개선
   - 한 번에 한 개 주문하는 테스트는 완료
   - 한 번에 100개의 주문을 테스트하는 것은 리팩토링 진행 하지 않아서 주석으로 남겨둠.
- 제품 목록 테스트 추가

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - `OrderRepository`와 `ProductRepository`에 모든 항목 삭제 기능 추가.
  - `ProductJpaRepository`에 여러 제품을 저장하는 기능 추가.
  - `ProductFixture` 클래스 추가로 테스트용 제품 객체 생성 기능 제공.

- **Bug Fixes**
  - 의존성 관리 개선으로 코드 구조 명확화.

- **Documentation**
  - 테스트 클래스 및 메서드에 대한 설명 추가 및 정리.

- **Tests**
  - `ProductServiceTest` 클래스 추가로 제품 서비스 기능 테스트 강화.
  - `OrderServiceTest`에서 테스트 구조 재정비 및 단일 구매 시나리오 테스트 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->