### PR TITLE
[feat/order] KafkaConsumer 클래스와 OrderService 책임 분리

### DIFF
--- a/src/main/java/com/example/hot_deal/common/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/example/hot_deal/common/config/kafka/KafkaConsumerConfig.java
@@ -11,14 +11,17 @@ import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
 import java.util.HashMap;
 import java.util.Map;
 
+import static com.example.hot_deal.common.constants.KafkaConstants.CONSUMER_GROUP_ID;
+
 @Configuration
 public class KafkaConsumerConfig {
+
     @Bean
     public ConsumerFactory<String, String> consumerFactory() {
         Map<String, Object> config = new HashMap<>();
 
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
-        config.put(ConsumerConfig.GROUP_ID_CONFIG, "group_1");
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, CONSUMER_GROUP_ID);
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
 

--- a/src/main/java/com/example/hot_deal/common/constants/KafkaConstants.java
+++ b/src/main/java/com/example/hot_deal/common/constants/KafkaConstants.java
@@ -1,0 +1,10 @@
+package com.example.hot_deal.common.constants;
+
+public class KafkaConstants {
+
+    public final static String PRODUCT_ORDER_TOPIC = "applied-users";
+
+    public final static String PRODUCT_ORDER_GROUP_ID = "order-group";
+
+    public final static String CONSUMER_GROUP_ID = "group_1";
+}

--- a/src/main/java/com/example/hot_deal/member/service/MemberService.java
+++ b/src/main/java/com/example/hot_deal/member/service/MemberService.java
@@ -52,7 +52,10 @@ public class MemberService {
      * 회원 정보 조회
      */
     public BaseMemberDTO findMemberById(Long id) {
-        final Member member = memberRepository.getMemberById(id);
-        return member.getBaseMemberDto();
+        return getMemberById(id).getBaseMemberDto();
+    }
+
+    public Member getMemberById(Long id) {
+        return memberRepository.getMemberById(id);
     }
 }

--- a/src/main/java/com/example/hot_deal/order/consumer/PurchasedUserOrderConsumer.java
+++ b/src/main/java/com/example/hot_deal/order/consumer/PurchasedUserOrderConsumer.java
@@ -13,6 +13,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Isolation;
 import org.springframework.transaction.annotation.Transactional;
 
+import static com.example.hot_deal.common.constants.KafkaConstants.PRODUCT_ORDER_GROUP_ID;
+import static com.example.hot_deal.common.constants.KafkaConstants.PRODUCT_ORDER_TOPIC;
+
+
 @Slf4j
 @Component
 @AllArgsConstructor
@@ -23,7 +27,7 @@ public class PurchasedUserOrderConsumer {
     private final ProductRepository productRepository;
 
     @Transactional(isolation = Isolation.READ_COMMITTED)
-    @KafkaListener(topics = "applied-users", groupId = "order-group")
+    @KafkaListener(topics = PRODUCT_ORDER_TOPIC, groupId = PRODUCT_ORDER_GROUP_ID)
     public void processOrder(String message) {
         PurchasedRequest request = PurchasedRequest.from(message);
 

--- a/src/main/java/com/example/hot_deal/order/domain/repository/PurchasedUserRepository.java
+++ b/src/main/java/com/example/hot_deal/order/domain/repository/PurchasedUserRepository.java
@@ -12,6 +12,11 @@ public class PurchasedUserRepository {
 
     private final KafkaTemplate<String, String> kafkaTemplate;
 
+    /**
+     * 구매 요청 Topic 에 메시지 전달
+     * @param userId 구매한 회원
+     * @param productId 구매 제품
+     */
     public void purchase(Long userId, Long productId) {
         String key = userId.toString();
         String value = userId + ":" + productId;

--- a/src/main/java/com/example/hot_deal/order/domain/repository/PurchasedUserRepository.java
+++ b/src/main/java/com/example/hot_deal/order/domain/repository/PurchasedUserRepository.java
@@ -4,6 +4,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.stereotype.Repository;
 
+import static com.example.hot_deal.common.constants.KafkaConstants.PRODUCT_ORDER_TOPIC;
+
 @Repository
 @RequiredArgsConstructor
 public class PurchasedUserRepository {
@@ -13,6 +15,6 @@ public class PurchasedUserRepository {
     public void purchase(Long userId, Long productId) {
         String key = userId.toString();
         String value = userId + ":" + productId;
-        kafkaTemplate.send("applied-users", key, value);
+        kafkaTemplate.send(PRODUCT_ORDER_TOPIC, key, value);
     }
 }

--- a/src/main/java/com/example/hot_deal/order/service/OrderService.java
+++ b/src/main/java/com/example/hot_deal/order/service/OrderService.java
@@ -1,6 +1,12 @@
 package com.example.hot_deal.order.service;
 
+import com.example.hot_deal.member.domain.entity.Member;
+import com.example.hot_deal.member.service.MemberService;
+import com.example.hot_deal.order.consumer.PurchasedRequest;
+import com.example.hot_deal.order.domain.entity.Order;
+import com.example.hot_deal.order.domain.repository.OrderRepository;
 import com.example.hot_deal.order.domain.repository.PurchasedUserRepository;
+import com.example.hot_deal.product.domain.entity.Product;
 import com.example.hot_deal.product.domain.repository.redis.ProductCountRepository;
 import com.example.hot_deal.product.domain.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -16,8 +22,11 @@ public class OrderService {
     private final ProductCountRepository productCountRepository;
     private final PurchasedUserRepository purchasedUserRepository;
 
+    private final OrderRepository orderRepository;
+    private final MemberService memberService;
+
     /**
-     * 물건 구매
+     * 물건 구매 요청
      * 1. 물건 구매 요청이 들어오면 레디스에서 물건 수량을 감소
      * 2. 물건 요청을 카프카에 기록 해뒀다가 카프카의 Consumer 가 메시지를 받아 순차적으로 재고를 감소(DB 반영)
      * @param userId 구매 주체
@@ -31,5 +40,19 @@ public class OrderService {
         );
 
         purchasedUserRepository.purchase(userId, productId);
+    }
+
+    /**
+     * 물건 구매 로직
+     * @param request 카프카에서 가지고 온 구매 요청 데이터
+     */
+    public void processOrderRequest(PurchasedRequest request) {
+        Member member = memberService.getMemberById(request.getMemberId());
+        Product product = productRepository.getProductById(request.getProductId());
+
+        product.decreaseQuantity();
+        productRepository.save(product);
+
+        orderRepository.save(new Order(member, product.getName()));
     }
 }

--- a/src/test/java/com/example/hot_deal/config/TestConfig.java
+++ b/src/test/java/com/example/hot_deal/config/TestConfig.java
@@ -20,6 +20,8 @@ import org.testcontainers.utility.DockerImageName;
 import java.time.Duration;
 import java.util.Map;
 
+import static com.example.hot_deal.common.constants.KafkaConstants.PRODUCT_ORDER_TOPIC;
+
 
 @Slf4j
 @TestConfiguration
@@ -57,7 +59,7 @@ public class TestConfig {
 
     @Bean
     public NewTopic appliedUsersTopic() {
-        return TopicBuilder.name("applied-users")
+        return TopicBuilder.name(PRODUCT_ORDER_TOPIC)
                 .partitions(1)
                 .replicas(1)
                 .build();


### PR DESCRIPTION
KafkaConsumer 클래스에서 주문 처리 로직을 담당하던 것을 OrderService로 분리 했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- Kafka 관련 상수 클래스를 추가하여 구성 관리 용이성 향상.
	- 주문 처리 요청을 위한 새로운 메서드 `processOrderRequest` 추가.

- **버그 수정**
	- 없음.

- **문서화**
	- `purchase` 메서드에 Javadoc 주석 추가.

- **리팩토링**
	- 여러 클래스의 메서드 로직을 개선하여 가독성과 유지보수성 향상.
	- `PurchasedUserOrderConsumer`에서 `OrderService`로의 의존성 변경.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->