### PR TITLE
[refactor/api] HTTP 응답 공통 포맷 wrapper 클래스 생성

### DIFF
--- a/src/main/java/com/example/hot_deal/common/config/web/ApiV1.java
+++ b/src/main/java/com/example/hot_deal/common/config/web/ApiV1.java
@@ -7,6 +7,9 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ *  ElementType.TYPE: 클래스, 인터페이스, enum에서 사용할 수 있는 애노테이션
+ */
 @Target(ElementType.TYPE)
 @Retention(value = RetentionPolicy.RUNTIME)
 @Component

--- a/src/main/java/com/example/hot_deal/common/config/web/CommonHttpMessageConverter.java
+++ b/src/main/java/com/example/hot_deal/common/config/web/CommonHttpMessageConverter.java
@@ -31,7 +31,12 @@ public class CommonHttpMessageConverter extends AbstractHttpMessageConverter<Api
     @Override
     protected boolean supports(Class<?> clazz) {
         log.info("1# CommonHttpMessageConverter - supports ");
-        return clazz.equals(ApiResponse.class) || clazz.isPrimitive() || clazz.equals(String.class);
+
+        // ApiResponse를 상속/구현하는 클래스까지 true 반환
+        return ApiResponse.class.isAssignableFrom(clazz);
+
+        // 특정 클래스인지 확인
+        // return clazz.equals(ApiResponse.class) || clazz.isPrimitive() || clazz.equals(String.class);
     }
 
     @Override

--- a/src/main/java/com/example/hot_deal/common/config/web/CommonHttpMessageConverter.java
+++ b/src/main/java/com/example/hot_deal/common/config/web/CommonHttpMessageConverter.java
@@ -1,0 +1,55 @@
+package com.example.hot_deal.common.config.web;
+
+import com.example.hot_deal.common.domain.ApiResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpInputMessage;
+import org.springframework.http.HttpOutputMessage;
+import org.springframework.http.converter.AbstractHttpMessageConverter;
+import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.http.converter.HttpMessageNotWritableException;
+import org.springframework.util.StreamUtils;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@Order(Ordered.HIGHEST_PRECEDENCE) // 순서대로 컨버터가 등록 되는데, 최우선 순위로 등록
+public class CommonHttpMessageConverter extends AbstractHttpMessageConverter<ApiResponse<Object>> {
+
+    private final ObjectMapper objectMapper;
+
+    public CommonHttpMessageConverter(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * supports가 true를 return 하면 해당 컨버터를 실행하게 됨
+     */
+    @Override
+    protected boolean supports(Class<?> clazz) {
+        log.info("1# CommonHttpMessageConverter - supports ");
+        return clazz.equals(ApiResponse.class) || clazz.isPrimitive() || clazz.equals(String.class);
+    }
+
+    @Override
+    protected ApiResponse<Object> readInternal(Class<? extends ApiResponse<Object>> clazz, HttpInputMessage inputMessage) throws IOException, HttpMessageNotReadableException {
+        return null;
+    }
+
+    /**
+     * HTTP 응답을 생성하는 메서드
+     * ApiResponse 객체를 JSON 형식으로 변환한 뒤 HTTP 응답
+     * @param resultMessage the object to write to the output message
+     * @param outputMessage the HTTP output message to write to
+     */
+    @Override
+    protected void writeInternal(ApiResponse<Object> resultMessage, HttpOutputMessage outputMessage) throws IOException, HttpMessageNotWritableException {
+        log.info("4# CommonHttpMessageConverter - writeInternal ");
+
+        String responseMessage = this.objectMapper.writeValueAsString(resultMessage); // JSON 포맷 변환
+        StreamUtils.copy(responseMessage.getBytes(StandardCharsets.UTF_8), outputMessage.getBody());
+    }
+}

--- a/src/main/java/com/example/hot_deal/common/config/web/ResponseWrapper.java
+++ b/src/main/java/com/example/hot_deal/common/config/web/ResponseWrapper.java
@@ -1,0 +1,54 @@
+package com.example.hot_deal.common.config.web;
+
+import com.example.hot_deal.common.domain.ApiResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.HttpMessageConverter;
+import org.springframework.http.server.ServerHttpRequest;
+import org.springframework.http.server.ServerHttpResponse;
+import org.springframework.web.ErrorResponse;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class ResponseWrapper implements ResponseBodyAdvice<Object> {
+
+
+    @Override
+    public boolean supports(MethodParameter returnType, Class<? extends HttpMessageConverter<?>> converterType) {
+        log.info("2# Execute ResponseWrapper - supports");
+        log.info("2# Execute ResponseWrapper - returnType :: {}", returnType);
+        log.info("2# Execute ResponseWrapper - converterType :: {}", converterType);
+
+        // 현재 요청 URI 확인
+        ServletRequestAttributes attrs = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+        if (attrs != null) {
+            String requestUri = attrs.getRequest().getRequestURI();
+            if (requestUri.startsWith("/v3/api-docs")) {
+                log.info("Skipping ResponseWrapper for Swagger-related requests: {}", requestUri);
+                return false; // Swagger 경로는 처리하지 않음
+            }
+        }
+
+        return true;
+    }
+
+    @Override
+    public Object beforeBodyWrite(Object body,
+                                  MethodParameter returnType,
+                                  MediaType selectedContentType,
+                                  Class<? extends HttpMessageConverter<?>> selectedConverterType,
+                                  ServerHttpRequest request,
+                                  ServerHttpResponse response
+    ) {
+        log.info("3# Execute ResponseWrapper - beforeBodyWrite");
+        if (body instanceof ErrorResponse) {
+            return new ApiResponse<>("ERROR", body);
+        }
+        return new ApiResponse<>("SUCCESS", body);
+    }
+}

--- a/src/main/java/com/example/hot_deal/common/domain/ApiResponse.java
+++ b/src/main/java/com/example/hot_deal/common/domain/ApiResponse.java
@@ -1,0 +1,17 @@
+package com.example.hot_deal.common.domain;
+
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+public class ApiResponse<T> {
+    private String status;
+    private T body;
+    private LocalDateTime timestamp = LocalDateTime.now();
+
+    public ApiResponse(String status, T body) {
+        this.status = status;
+        this.body = body;
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
	- API 응답을 표준화하는 `ApiResponse` 클래스 추가.
	- HTTP 응답을 수정하는 `ResponseWrapper` 클래스 추가.
	- 사용자 정의 HTTP 메시지 변환기인 `CommonHttpMessageConverter` 클래스 추가.
	- 새로운 주석 `ApiV1` 추가로 API 버전 관리 용이.

- **버그 수정**
	- Swagger 관련 요청을 처리에서 제외하여 불필요한 응답 수정 방지.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->